### PR TITLE
Fix dependency issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
+    ansi (1.5.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -34,6 +35,11 @@ GEM
     method_source (0.8.2)
     mini_portile (0.6.2)
     minitest (5.8.0)
+    minitest-reporters (1.1.0)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     nori (2.6.0)
@@ -43,6 +49,7 @@ GEM
       slop (~> 3.4)
     rack (1.6.4)
     rake (10.4.2)
+    ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
     savon (2.10.1)
       akami (~> 1.2)
@@ -78,6 +85,7 @@ DEPENDENCIES
   also_energy!
   bundler (~> 1.10)
   minitest
+  minitest-reporters
   pry
   rake (~> 10.0)
   vcr

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require "rake/testtask"
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList['test/**/*_test.rb']
+  t.test_files = FileList['test/**/*_spec.rb', 'test/**/*_test.rb']
 end
 
 task :default => :test

--- a/also_energy.gemspec
+++ b/also_energy.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
+  spec.add_development_dependency "minitest-reporters"
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"
 

--- a/lib/also_energy.rb
+++ b/lib/also_energy.rb
@@ -1,4 +1,7 @@
-require "also_energy/version"
+require 'savon'
+require 'virtus'
+
+require 'also_energy/version'
 require 'also_energy/client'
 
 module AlsoEnergy

--- a/lib/also_energy/client.rb
+++ b/lib/also_energy/client.rb
@@ -1,10 +1,7 @@
-require 'savon'
-require 'pry'
-require 'virtus'
-require './lib/also_energy/hash_wrangler'
-require './lib/also_energy/connection'
-require './lib/also_energy/site'
-require './lib/also_energy/hardware'
+require 'also_energy/hash_wrangler'
+require 'also_energy/connection'
+require 'also_energy/site'
+require 'also_energy/hardware'
 
 module AlsoEnergy
   class AuthError < StandardError; end

--- a/lib/also_energy/version.rb
+++ b/lib/also_energy/version.rb
@@ -1,3 +1,3 @@
 module AlsoEnergy
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require './lib/also_energy'
 require 'minitest/autorun'
 require 'webmock/minitest'
+require 'minitest/reporters'
 # require 'vcr'
 require 'pry'
 


### PR DESCRIPTION
This fixes the issue where dependencies were being included using the
relative path. I.E. `require './lib/also_energy/hash_wrangler'. This was
causing the gem to try to locat the file from a relative path, which is
fine in development, but doesn't work in a production environment. It
changes the require statements to 'also_energy/hash_wrangler'.
